### PR TITLE
Add mailto link to performance feedback in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Conductor also now supports message queues! Submit multiple messages and they wi
 
 Improvements: 
 
-- Performance improvements (if Conductor is running slowly for you, please let us know!)
+- Performance improvements (if Conductor is running slowly for you, [please let us know](mailto:founders@melty.sh?subject=Conductor%20perf%20issues)!)
 - Add a setting to customize the auto-compact threshold
 - The `Compact and Continue` error button now re-sends your last message
 - Navigate between workspaces easily with shortcuts (`⌘+1→9`)


### PR DESCRIPTION
## Summary
- Added mailto link to "please let us know" text in CHANGELOG.md
- Link directs to founders@melty.sh with subject "Conductor perf issues"
- Makes it easier for users to provide performance feedback

## Test plan
- [x] Verify the mailto link is properly formatted in the CHANGELOG.md
- [x] Test that clicking the link opens email client with correct recipient and subject

🤖 Generated with [Claude Code](https://claude.ai/code)