### PR TITLE
Test: Add failing CI job

### DIFF
--- a/.github/workflows/test-failing-ci.yml
+++ b/.github/workflows/test-failing-ci.yml
@@ -1,0 +1,17 @@
+name: Test Failing CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - test-ci-failure
+
+jobs:
+  always-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fail instantly
+        run: exit 1


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that always fails instantly
- Used to test system integration with failing CI checks

## Test plan
- [ ] Verify the CI job runs on this PR
- [ ] Confirm the job fails immediately
- [ ] Test how the system handles the failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)